### PR TITLE
feat(operator-signup): add Operator sign-up flow (backend & UI)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,14 +8,16 @@ import MaintenanceForm from './MaintenanceForm';
 import CustomerSelection from './CustomerSelection';
 import SignupPage from './SignupPage';
 import TechnicianSignup from './TechnicianSignup';
+import OperatorSignup from './OperatorSignup';
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<LoginPage />} />
-        <Route path="/signup" element={<SignupPage />} />                     {}
-        <Route path="/signup/technician" element={<TechnicianSignup />} />    {}
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/signup/technician" element={<TechnicianSignup />} />
+        <Route path="/signup/operator" element={<OperatorSignup />} />
         <Route path="/select-customer" element={<CustomerSelection />} />
         <Route path="/dashboard" element={<TechnicianDashboard />} />
         <Route path="/operator" element={<OperatorDashboard />} />

--- a/frontend/src/OperatorSignup.jsx
+++ b/frontend/src/OperatorSignup.jsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function OperatorSignup() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+    customerId: ''
+  });
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  const onChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await fetch('/api/operators/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name.trim(),
+          email: form.email.trim(),
+          password: form.password,
+          customerId: Number(form.customerId)
+        })
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setMsg(data?.message || 'Sign up failed.');
+      } else {
+        setMsg('Operator created!');
+        // optional: route somewhere after success
+        // navigate('/operator');
+      }
+    } catch (err) {
+      setMsg('Network error.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const card = {
+    maxWidth: 420,
+    margin: '80px auto',
+    padding: '2rem',
+    background: '#fff',
+    borderRadius: 8,
+    boxShadow: '0 0 10px rgba(0,0,0,0.1)',
+    textAlign: 'left'
+  };
+
+  return (
+    <div style={card}>
+      <h2>New Operator</h2>
+      <p style={{ color: '#666' }}>
+        Create an operator account associated with a customer.
+      </p>
+
+      <form onSubmit={onSubmit} style={{ display: 'grid', gap: '0.75rem', marginTop: '1rem' }}>
+        <div>
+          <label>Name</label>
+          <input
+            name="name"
+            value={form.name}
+            onChange={onChange}
+            placeholder="Full name"
+            required
+          />
+        </div>
+
+        <div>
+          <label>Email</label>
+          <input
+            name="email"
+            type="email"
+            value={form.email}
+            onChange={onChange}
+            placeholder="name@example.com"
+            required
+          />
+        </div>
+
+        <div>
+          <label>Password</label>
+          <input
+            name="password"
+            type="password"
+            value={form.password}
+            onChange={onChange}
+            required
+          />
+        </div>
+
+        <div>
+          <label>Customer ID</label>
+          <input
+            name="customerId"
+            type="number"
+            value={form.customerId}
+            onChange={onChange}
+            placeholder="e.g. 2"
+            required
+          />
+        </div>
+
+        <button type="submit" disabled={loading}>
+          {loading ? 'Creating…' : 'Create Operator'}
+        </button>
+      </form>
+
+      {msg && <p style={{ marginTop: '1rem' }}>{msg}</p>}
+
+      <button onClick={() => navigate('/signup')} style={{ marginTop: '1rem', width: '100%' }}>
+        Back
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/SignupPage.jsx
+++ b/frontend/src/SignupPage.jsx
@@ -21,30 +21,59 @@ const SignupPage = () => {
   };
 
   return (
-    <div style={{
-      maxWidth: 720, margin: '80px auto', padding: '2rem',
-      background: '#fff', borderRadius: 8, boxShadow: '0 0 10px rgba(0,0,0,0.1)'
-    }}>
+    <div
+      style={{
+        maxWidth: 720,
+        margin: '80px auto',
+        padding: '2rem',
+        background: '#fff',
+        borderRadius: 8,
+        boxShadow: '0 0 10px rgba(0,0,0,0.1)',
+      }}
+    >
       <h2>Create an account</h2>
-      <p style={{ marginTop: 8, color: '#666' }}>Only Technician sign-up is enabled right now.</p>
+      <p style={{ marginTop: 8, color: '#666' }}>
+        Technician and Operator sign-up are enabled right now.
+      </p>
 
-      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', marginTop: '1rem', justifyContent: 'center' }}>
+      <div
+        style={{
+          display: 'flex',
+          gap: '1rem',
+          flexWrap: 'wrap',
+          marginTop: '1rem',
+          justifyContent: 'center',
+        }}
+      >
+        {/* Technician */}
         <div
           style={card}
           onClick={() => navigate('/signup/technician')}
           role="button"
           tabIndex={0}
-          onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && navigate('/signup/technician')}
+          onKeyDown={(e) =>
+            (e.key === 'Enter' || e.key === ' ') && navigate('/signup/technician')
+          }
         >
           <h3>New Technician</h3>
           <p>Set up a technician login</p>
         </div>
 
-        <div style={disabledCard} aria-disabled="true">
+        {/* Operator (enabled) */}
+        <div
+          style={card}
+          onClick={() => navigate('/signup/operator')}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) =>
+            (e.key === 'Enter' || e.key === ' ') && navigate('/signup/operator')
+          }
+        >
           <h3>New Operator</h3>
-          <p>(Coming soon)</p>
+          <p>Set up an operator login</p>
         </div>
 
+        {/* Customer User (disabled / coming soon) */}
         <div style={disabledCard} aria-disabled="true">
           <h3>New Customer User</h3>
           <p>(Coming soon)</p>

--- a/src/main/java/com/ManageLift/forkliftmanagement/controller/OperatorController.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/controller/OperatorController.java
@@ -1,0 +1,82 @@
+package com.managelift.forkliftmanagement.controller;
+
+import com.managelift.forkliftmanagement.model.Customer;
+import com.managelift.forkliftmanagement.model.Operator;
+import com.managelift.forkliftmanagement.model.User;
+import com.managelift.forkliftmanagement.repository.CustomerRepository;
+import com.managelift.forkliftmanagement.repository.OperatorRepository;
+import com.managelift.forkliftmanagement.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/operators")
+public class OperatorController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OperatorRepository operatorRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @PostMapping("/signup")
+    @Transactional
+    public ResponseEntity<?> signup(@RequestBody SignupRequest req) {
+        if (req == null || isBlank(req.name) || isBlank(req.email) || isBlank(req.password) || req.customerId == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", "name, email, password, and customerId are required"));
+        }
+
+        if (userRepository.findByEmail(req.email).isPresent()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("message", "Email already in use"));
+        }
+
+        Customer customer = customerRepository.findById(req.customerId)
+                .orElse(null);
+        if (customer == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("message", "Customer not found: " + req.customerId));
+        }
+
+        User user = new User();
+        user.setName(req.name);
+        user.setEmail(req.email);
+        user.setPassword(req.password);
+        user.setRole("Operator");
+        user = userRepository.save(user);
+
+
+        Operator op = new Operator(user, customer);
+        op = operatorRepository.save(op);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message", "Operator created",
+                "userId", user.getId(),
+                "operatorId", op.getId(),
+                "customerId", customer.getId(),
+                "name", user.getName(),
+                "email", user.getEmail(),
+                "role", user.getRole()
+        ));
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    public static class SignupRequest {
+        public String name;
+        public String email;
+        public String password;
+        public Long customerId;
+    }
+}

--- a/src/main/java/com/ManageLift/forkliftmanagement/controller/OperatorSignupDTO.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/controller/OperatorSignupDTO.java
@@ -1,0 +1,9 @@
+
+package com.managelift.forkliftmanagement.controller;
+
+public record OperatorSignupDTO(
+        String name,
+        String email,
+        String password,
+        Long customerId
+) {}

--- a/src/main/java/com/ManageLift/forkliftmanagement/model/Operator.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/model/Operator.java
@@ -1,0 +1,77 @@
+package com.managelift.forkliftmanagement.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+        name = "operators",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "operators_user_id_uk", columnNames = "user_id")
+        },
+        indexes = {
+                @Index(name = "operators_customer_id_idx", columnList = "customer_id")
+        }
+)
+public class Operator {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            unique = true,
+            foreignKey = @ForeignKey(name = "operators_user_id_fk")
+    )
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "customer_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "operators_customer_id_fk")
+    )
+    private Customer customer;
+
+    protected Operator() {
+        // JPA
+    }
+
+    public Operator(User user, Customer customer) {
+        this.user = user;
+        this.customer = customer;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
+    public void setCustomer(Customer customer) {
+        this.customer = customer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Operator)) return false;
+        Operator other = (Operator) o;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31;
+    }
+}

--- a/src/main/java/com/ManageLift/forkliftmanagement/repository/OperatorRepository.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/repository/OperatorRepository.java
@@ -1,0 +1,13 @@
+package com.managelift.forkliftmanagement.repository;
+
+import com.managelift.forkliftmanagement.model.Operator;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OperatorRepository extends JpaRepository<Operator, Long> {
+    boolean existsByUser_Id(Long userId);
+    Optional<Operator> findByUser_Id(Long userId);
+}


### PR DESCRIPTION
feat(operator-signup): add Operator sign-up flow (backend & UI)

- Add Operator entity (user_id unique FK, customer_id FK with index)
- Create OperatorRepository with existsByUserId/findByUserId
- Introduce OperatorSignupDTO (controller.dto)
- Implement POST /api/operators/signup:
  - enforce global email uniqueness
  - create User(role=Operator) + Operator(customerId) atomically
- Frontend:
  - Add OperatorSignup.jsx page and route (/signup/operator)
  - Enable “New Operator” option on signup gateway
- Minor UI/routing wiring; no changes to password scheme (as planned)
