### PR TITLE
feat(signup): add Customer User sign-up flow (API + UI)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+
 import LoginPage from './LoginPage';
 import TechnicianDashboard from './TechnicianDashboard';
 import OperatorDashboard from './OperatorDashboard';
 import CustomerDashboard from './CustomerDashboard';
 import MaintenanceForm from './MaintenanceForm';
 import CustomerSelection from './CustomerSelection';
+
 import SignupPage from './SignupPage';
 import TechnicianSignup from './TechnicianSignup';
 import OperatorSignup from './OperatorSignup';
+import CustomerSignup from './CustomerSignup';
 
 function App() {
   return (
@@ -18,6 +21,7 @@ function App() {
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/signup/technician" element={<TechnicianSignup />} />
         <Route path="/signup/operator" element={<OperatorSignup />} />
+        <Route path="/signup/customer" element={<CustomerSignup />} /> {}
         <Route path="/select-customer" element={<CustomerSelection />} />
         <Route path="/dashboard" element={<TechnicianDashboard />} />
         <Route path="/operator" element={<OperatorDashboard />} />

--- a/frontend/src/CustomerSignup.jsx
+++ b/frontend/src/CustomerSignup.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function CustomerSignup() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ name: '', email: '', password: '', customerId: '' });
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  const onChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true); setMsg(null);
+    try {
+      const res = await fetch('/api/customer-users/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name.trim(),
+          email: form.email.trim(),
+          password: form.password,
+          customerId: Number(form.customerId),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) setMsg(data?.message ?? 'Sign up failed.');
+      else setMsg('Customer user created!');
+    } catch (err) {
+      console.error(err);
+      setMsg('Network error.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 420, margin: '80px auto', background: '#fff', padding: '1.5rem', borderRadius: 8 }}>
+      <h2>New Customer User</h2>
+      <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <input name="name" placeholder="Full name" value={form.name} onChange={onChange} required />
+        <input name="email" placeholder="Email" value={form.email} onChange={onChange} required />
+        <input name="password" placeholder="Password" type="password" value={form.password} onChange={onChange} required />
+        <input name="customerId" placeholder="Customer ID (temporary)" value={form.customerId} onChange={onChange} required />
+        <button type="submit" disabled={loading}>{loading ? 'Creating…' : 'Create account'}</button>
+      </form>
+      {msg && <p style={{ marginTop: 10 }}>{msg}</p>}
+      <button onClick={() => navigate('/signup')} style={{ marginTop: 12 }}>Back</button>
+    </div>
+  );
+}

--- a/frontend/src/SignupPage.jsx
+++ b/frontend/src/SignupPage.jsx
@@ -13,12 +13,6 @@ const SignupPage = () => {
     cursor: 'pointer',
     background: '#fff',
   };
-  const disabledCard = {
-    ...card,
-    opacity: 0.5,
-    cursor: 'not-allowed',
-    pointerEvents: 'none',
-  };
 
   return (
     <div
@@ -33,7 +27,7 @@ const SignupPage = () => {
     >
       <h2>Create an account</h2>
       <p style={{ marginTop: 8, color: '#666' }}>
-        Technician and Operator sign-up are enabled right now.
+        Technician, Operator, and Customer User sign-up are enabled right now.
       </p>
 
       <div
@@ -45,7 +39,7 @@ const SignupPage = () => {
           justifyContent: 'center',
         }}
       >
-        {/* Technician */}
+        {}
         <div
           style={card}
           onClick={() => navigate('/signup/technician')}
@@ -59,7 +53,7 @@ const SignupPage = () => {
           <p>Set up a technician login</p>
         </div>
 
-        {/* Operator (enabled) */}
+        {}
         <div
           style={card}
           onClick={() => navigate('/signup/operator')}
@@ -73,10 +67,18 @@ const SignupPage = () => {
           <p>Set up an operator login</p>
         </div>
 
-        {/* Customer User (disabled / coming soon) */}
-        <div style={disabledCard} aria-disabled="true">
+        {}
+        <div
+          style={card}
+          onClick={() => navigate('/signup/customer')}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) =>
+            (e.key === 'Enter' || e.key === ' ') && navigate('/signup/customer')
+          }
+        >
           <h3>New Customer User</h3>
-          <p>(Coming soon)</p>
+          <p>Create a login for your company</p>
         </div>
       </div>
 

--- a/src/main/java/com/ManageLift/forkliftmanagement/controller/CustomerUserController.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/controller/CustomerUserController.java
@@ -1,0 +1,69 @@
+package com.managelift.forkliftmanagement.controller;
+
+import com.managelift.forkliftmanagement.model.Customer;
+import com.managelift.forkliftmanagement.model.CustomerUser;
+import com.managelift.forkliftmanagement.model.User;
+import com.managelift.forkliftmanagement.repository.CustomerRepository;
+import com.managelift.forkliftmanagement.repository.CustomerUserRepository;
+import com.managelift.forkliftmanagement.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/customer-users")
+public class CustomerUserController {
+
+    private final UserRepository userRepository;
+    private final CustomerRepository customerRepository;
+    private final CustomerUserRepository customerUserRepository;
+
+    public CustomerUserController(
+            UserRepository userRepository,
+            CustomerRepository customerRepository,
+            CustomerUserRepository customerUserRepository
+    ) {
+        this.userRepository = userRepository;
+        this.customerRepository = customerRepository;
+        this.customerUserRepository = customerUserRepository;
+    }
+
+    @PostMapping("/signup")
+    @Transactional
+    public ResponseEntity<?> signup(@RequestBody CustomerUserSignupDTO req) {
+        if (userRepository.findByEmail(req.email()).isPresent()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("message", "Email already in use"));
+        }
+
+        Customer customer = customerRepository.findById(req.customerId())
+                .orElse(null);
+        if (customer == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", "Invalid customerId"));
+        }
+
+        User user = new User();
+        user.setName(req.name());
+        user.setEmail(req.email());
+        user.setPassword(req.password());
+        user.setRole("Customer");
+        user = userRepository.save(user);
+
+        CustomerUser cu = new CustomerUser(user, customer);
+        cu = customerUserRepository.save(cu);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message", "Customer user created",
+                "userId", user.getId(),
+                "customerUserId", cu.getId(),
+                "customerId", customer.getId(),
+                "name", user.getName(),
+                "email", user.getEmail(),
+                "role", user.getRole()
+        ));
+    }
+}

--- a/src/main/java/com/ManageLift/forkliftmanagement/controller/CustomerUserSignupDTO.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/controller/CustomerUserSignupDTO.java
@@ -1,0 +1,8 @@
+package com.managelift.forkliftmanagement.controller;
+
+public record CustomerUserSignupDTO(
+        String name,
+        String email,
+        String password,
+        Long customerId
+) {}

--- a/src/main/java/com/ManageLift/forkliftmanagement/model/CustomerUser.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/model/CustomerUser.java
@@ -1,0 +1,65 @@
+package com.managelift.forkliftmanagement.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+        name = "customer_users",
+        uniqueConstraints = {
+                // String[] required for columnNames
+                @UniqueConstraint(name = "customer_users_user_id_uk", columnNames = {"user_id"})
+        },
+        indexes = {
+                // In Jakarta persistence use columnList (NOT columnNames)
+                @Index(name = "customer_users_customer_id_idx", columnList = "customer_id")
+        }
+)
+public class CustomerUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            unique = true,
+            foreignKey = @ForeignKey(name = "customer_users_user_id_fk")
+    )
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "customer_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "customer_users_customer_id_fk")
+    )
+    private Customer customer;
+
+    protected CustomerUser() { }
+
+    public CustomerUser(User user, Customer customer) {
+        this.user = user;
+        this.customer = customer;
+    }
+
+    public Long getId() { return id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Customer getCustomer() { return customer; }
+    public void setCustomer(Customer customer) { this.customer = customer; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CustomerUser)) return false;
+        CustomerUser other = (CustomerUser) o;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() { return 31; }
+}

--- a/src/main/java/com/ManageLift/forkliftmanagement/repository/CustomerUserRepository.java
+++ b/src/main/java/com/ManageLift/forkliftmanagement/repository/CustomerUserRepository.java
@@ -1,0 +1,11 @@
+package com.managelift.forkliftmanagement.repository;
+
+import com.managelift.forkliftmanagement.model.CustomerUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CustomerUserRepository extends JpaRepository<CustomerUser, Long> {
+    boolean existsByUserId(Long userId);
+    Optional<CustomerUser> findByUserId(Long userId);
+}


### PR DESCRIPTION
feat(signup): add Customer User sign-up flow (API + UI)

- Backend:
  - Add CustomerUser entity with unique user FK and customer index
  - Add CustomerUserRepository and CustomerUserSignupDTO
  - Add CustomerUserController: POST /api/customer-users/signup
- Frontend:
  - Add CustomerSignup page and route (/signup/customer)
  - Enable “New Customer User” card on SignupPage
  - Wire to API, show basic success/error states

Also: keep Operator/Technician flows intact; no breaking changes.
